### PR TITLE
do not respond for unrecognized messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -447,8 +447,6 @@ async def handle_text_input(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await show_settings_menu(update, context, is_admin=is_admin)
         return
 
-    await update.message.reply_text("I didn't understand that. Please use /start to see available commands.")
-
 # ==============================================================================
 # USER MANAGEMENT MENU (Admin)
 # ==============================================================================


### PR DESCRIPTION
Inside a group chat, the bot constantly messages you with "I didn't understand that" for regular messages between members of the group. This is annoying so lets remove the message :)